### PR TITLE
functions for creating FiffInfo based on fieldline chassis parameters.

### DIFF
--- a/src/applications/mne_scan/plugins/fieldline/fieldline.cpp
+++ b/src/applications/mne_scan/plugins/fieldline/fieldline.cpp
@@ -56,10 +56,12 @@
 
 // #include <QSettings>
 #include <QDebug>
-#include <QLabel>
-#include <QVBoxLayout>
 #include <QHBoxLayout>
+#include <QLabel>
 #include <QSpacerItem>
+#include <QVBoxLayout>
+#include <numeric>
+#include <vector>
 
 //=============================================================================================================
 // EIGEN INCLUDES
@@ -72,12 +74,68 @@
 namespace FIELDLINEPLUGIN {
 
 //=============================================================================================================
+
+// QSharedPointer<FIFFLIB::FiffInfo> createFiffInfo(int numChassis,
+//                                                  int numChannels) {
+//   QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo;
+//   pFiffInfo->sfreq = 1000.0f;
+//   pFiffInfo->nchan = numChassis * numChannels;
+//   pFiffInfo->chs.clear();
+//
+//   for (int chan_i = 0; chan_i < pFiffInfo->nchan; ++chan_i) {
+//     FIFFLIB::FiffChInfo channel;
+//     channel.ch_name = QString("%1:%2").arg(numChannels, 2).arg(chan_i, 2);
+//     channel.kind = FIFFV_MEG_CH;
+//     channel.unit = FIFF_UNIT_T;
+//     channel.unit_mul = FIFF_UNITM_NONE;
+//     channel.chpos.coil_type = FIFFV_COIL_NONE;
+//     pFiffInfo->chs.append(channel);
+//     pFiffInfo->ch_names.append(channel.ch_name);
+//   }
+// }
+
+QSharedPointer<FIFFLIB::FiffInfo>
+createFiffInfo(std::vector<std::vector<int>> fl_chassis, float sfreq = 1000.f) {
+  QSharedPointer<FIFFLIB::FiffInfo> pFiffInfo;
+  pFiffInfo->sfreq = sfreq;
+  pFiffInfo->chs.clear();
+
+  int total_channels = 0;
+  int chassis_num = 0;
+  for (auto &chassis : fl_chassis) {
+    for (auto &sensor : chassis) {
+      FIFFLIB::FiffChInfo channel;
+      channel.ch_name = QString("%1:%2").arg(chassis_num, 2).arg(sensor, 2);
+      channel.kind = FIFFV_MEG_CH;
+      channel.unit = FIFF_UNIT_T;
+      channel.unit_mul = FIFF_UNITM_NONE;
+      channel.chpos.coil_type = FIFFV_COIL_NONE;
+      pFiffInfo->chs.append(channel);
+      pFiffInfo->ch_names.append(channel.ch_name);
+      ++total_channels;
+    }
+  }
+  pFiffInfo->nchan = total_channels;
+
+  return pFiffInfo;
+}
+
+QSharedPointer<FIFFLIB::FiffInfo>
+createFiffInfo(int numChassis, int numChannels, float sfreq = 1000.f) {
+  std::vector<std::vector<int>> fl;
+  for (int i = 0; i < numChassis; ++i) {
+    std::vector<int> ch(numChannels);
+    std::iota(ch.begin(), ch.end(), 1);
+    fl.push_back(std::move(ch));
+  }
+  return createFiffInfo(fl, sfreq);
+}
+
+//=============================================================================================================
 // DEFINE MEMBER METHODS
 //=============================================================================================================
 
-Fieldline::Fieldline() {
-  qDebug() << "Creating Fieldline object";
-}
+Fieldline::Fieldline() { qDebug() << "Creating Fieldline object"; }
 
 //=============================================================================================================
 
@@ -101,12 +159,11 @@ QSharedPointer<SCSHAREDLIB::AbstractPlugin> Fieldline::clone() const {
 
 void Fieldline::init() {
 
-  // we instantiante  
-  m_pRTMSA_Fieldline = SCSHAREDLIB::PluginOutputData<SCMEASLIB::RealTimeMultiSampleArray>::create(
-      this,
-      "Fieldline Plugin",
-      "FieldlinePlguin output");
-  
+  // we instantiante
+  m_pRTMSA_Fieldline = SCSHAREDLIB::PluginOutputData<
+      SCMEASLIB::RealTimeMultiSampleArray>::create(this, "Fieldline Plugin",
+                                                   "FieldlinePlguin output");
+
   m_outputConnectors.append(m_pRTMSA_Fieldline);
 
   qDebug() << " ^^^^^^^^^^^^^^^^^^^^ Init Fieldline  (....again)";
@@ -115,9 +172,7 @@ void Fieldline::init() {
 
 //=============================================================================================================
 
-void Fieldline::unload() { 
-  qDebug() << "unload Fieldline"; 
-}
+void Fieldline::unload() { qDebug() << "unload Fieldline"; }
 
 //=============================================================================================================
 
@@ -196,13 +251,10 @@ QWidget *Fieldline::setupWidget() {
   // init properties dialog
   //  widget->initGui();
 
-
-
-
-  auto* frame = new QWidget();
+  auto *frame = new QWidget();
   frame->setLayout(new QHBoxLayout());
 
-  auto* flWidget = new DISPLIB::FieldlineView(2, 16);
+  auto *flWidget = new DISPLIB::FieldlineView(2, 16);
 
   frame->layout()->addWidget(flWidget);
   flWidget->setBlinkState(0, 2, true);
@@ -245,7 +297,8 @@ void Fieldline::run() {
     m_pFiffInfo->ch_names.append(channel.ch_name);
   }
 
-  m_pRTMSA_Fieldline->measurementData()->initFromFiffInfo(m_pFiffInfo);  //     if(m_pCircularBuffer->pop(matData)) {
+  m_pRTMSA_Fieldline->measurementData()->initFromFiffInfo(
+      m_pFiffInfo); //     if(m_pCircularBuffer->pop(matData)) {
   m_pRTMSA_Fieldline->measurementData()->setMultiArraySize(1);
   m_pRTMSA_Fieldline->measurementData()->setVisibility(true);
 
@@ -253,19 +306,19 @@ void Fieldline::run() {
   matData.resize(m_pFiffInfo->nchan, 200);
   // matData.setZero();
 
-  for(;;) {
-    //gather the data
+  for (;;) {
+    // gather the data
 
     matData = Eigen::MatrixXd::Random(m_pFiffInfo->nchan, 200);
     matData *= 4e-12;
 
     msleep(200);
 
-    if (isInterruptionRequested()) 
+    if (isInterruptionRequested())
       break;
     m_pRTMSA_Fieldline->measurementData()->setValue(matData);
   }
-  
+
   //         //emit values
   //         if(!isInterruptionRequested()) {
   //             m_pRMTSA_Natus->measurementData()->setValue(matData);

--- a/src/applications/mne_scan/plugins/fieldline/fieldline_acq_system_controller.cpp
+++ b/src/applications/mne_scan/plugins/fieldline/fieldline_acq_system_controller.cpp
@@ -43,8 +43,68 @@
 
 #include "fieldline_acq_system_controller.h"
 
-namespace FIELDLINEPLUGIN {
+#include <iomanip>
+#include <iostream>
 
+extern "C" {
+
+PyObject *restartFinished(PyObject *self, PyObject *args) {
+  long chassis, sensor;
+  if (PyArg_ParseTuple(args, "ii", &chassis, &sensor)) {
+    std::cout << std::setfill('0') << std::setw(2) << chassis << ":" << sensor
+              << " - restart finished;\n";
+  } else {
+    std::cout << "A sensor has finished restarting!\n";
+  }
+
+  return NULL;
+}
+PyObject *coarseZeroFinished(PyObject *self, PyObject *args) {
+  long chassis, sensor;
+  if (PyArg_ParseTuple(args, "ii", &chassis, &sensor)) {
+    std::cout << std::setfill('0') << std::setw(2) << chassis << ":" << sensor
+              << " - coarse zero finished;\n";
+  } else {
+    std::cout << "A sensor has finished coarse zeroing!\n";
+  }
+
+  return NULL;
+}
+PyObject *fineZeroFinished(PyObject *self, PyObject *args) {
+  long chassis, sensor;
+  if (PyArg_ParseTuple(args, "ii", &chassis, &sensor)) {
+    std::cout << std::setfill('0') << std::setw(2) << chassis << ":" << sensor
+              << " - fine zero finished;\n";
+  } else {
+    std::cout << "A sensor has finished fine zeroing!\n";
+  }
+
+  return NULL;
+}
+}
+
+static PyMethodDef my_module_methods[] = {
+    {"restartFinished", restartFinished, METH_VARARGS, " "},
+    {"coarseZeroFinished", coarseZeroFinished, METH_VARARGS, " "},
+    {"fineZeroFinished", fineZeroFinished, METH_VARARGS, " "},
+    {NULL, NULL, 0, NULL}};
+
+static PyModuleDef my_module_def = {
+    PyModuleDef_HEAD_INIT,
+    "mne_cpp_callbacks",
+    "A module of callback functions for mne-cpp.",
+    -1,
+    my_module_methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL};
+
+PyMODINIT_FUNC PyInit_my_module(void) {
+  return PyModule_Create(&my_module_def);
+}
+
+namespace FIELDLINEPLUGIN {
 FieldlineAcqSystemController::FieldlineAcqSystemController() noexcept {
 
   // pythonInterpreter initiate


### PR DESCRIPTION
Wrote some functions for creating FiffInfo for a fieldline setup. Added them to fieldline.cpp for now but that is not where they need to end up, they can be moved to be members of something else later on if need be.

Two overloads available:
 - (int, int) -> pass in number of chassis and number of sensors per chassis. To be used if we just want al channels showing.
 - {{int}} -> pass in only the sensors we want, for example {{1,2,3,5,6,7,8},{2,3,4,5,6,7,8}}.
 
Both will create FiffInfo with channels named cc:ss, where cc is chassis num, zero indexed, and ss is sensor num, 1 indexed, like in the fieldline chassis. so we get something like this : "00:01", "00:02", etc.